### PR TITLE
Fix POST /meets/:id/interest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - In Progress
 
++ [[Backend-212]](https://www.notion.so/Talle-S-Deshabilitar-la-opci-n-de-aceptar-nuevos-interesados-12024a6692a4807598ddc01449c1fb4e)
++ An user cannot interest in a cancelled or completed meet.
 
 + [[Backend-255]](https://www.notion.so/Talle-M-Actualizar-el-estado-de-las-reuniones-pasadas-a-finished-5753d477aa974851b6c11975ecb91d7e?pvs=4)
 + Verificacion del estado completed de las meets
@@ -33,9 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-+ [[Backend-223]](https://www.notion.so/Talle-M-Unit-testing-of-Topics-Controller-a66bd212d0c34d70af6fd12012e617d5?pvs=4)
-+ Unit Testing para Topics Controller
-+ 
 + [[Backend-317]](https://www.notion.so/Seguimiento-de-incidencias-581e3acc7b124c229e12c0664c00b05e?p=b8b8e463edba4a9e8dc896db1e72d343&pm=s)
 + Added field `tutor` in GET /available_meet response with fields `id` and `name`.
 
@@ -81,10 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [[Backend-180]](https://www.notion.so/Talle-M-Endpoint-reuniones-existentes-b4a7d3d80788448b98962ebb95a6f221?pvs=4)
 + New list available meetings endpoint
-
-- [[Backend-140]](https://www.notion.so/Talle-S-Crear-modificar-endpoint-para-listar-los-temas-11624a6692a480b1bf51dc0fdc43925c)
-+ Updated endpoint `/topics` with new field `intrested`.
-+ Added new user. This user is interested in two topics.
 
 - [[Backend-143]](https://www.notion.so/Talle-M-Crear-modificar-endpoint-para-listar-las-meetings-en-las-que-el-usuario-est-anotado-11624a6692a480aa830dc9120393c6b3?pvs=4)
 + Added new enpoint to list my interested meetings as a student

--- a/app/controllers/meets_controller.rb
+++ b/app/controllers/meets_controller.rb
@@ -99,6 +99,11 @@ class MeetsController < ApplicationController
           debug_messages << "User's interest added to availability tutor."
         end
 
+        if meet.status == "cancelled" || meet.status == "completed"
+          render json: { error: "You cannot express interest in a #{meet.status} meet", debug: debug_messages }, status: :bad_request
+          return
+        end
+
         if meet.users.include?(@current_user.first)
           render json: { error: "User already interested in this meet", debug: debug_messages }, status: :bad_request
         else


### PR DESCRIPTION
# PULL REQUEST
:rocket: :rocket: 
### Descripción
Se agrega la lógica de no poder interesarse en una meet que esté cancelada o completada.

### Links requerimiento
[[Backend-212]](https://www.notion.so/Talle-S-Deshabilitar-la-opci-n-de-aceptar-nuevos-interesados-12024a6692a4807598ddc01449c1fb4e)

#### Test
Se realizan los siguientes test unitarios para probar el fix:
- Probar interesarse en una meet cancelada: Se crea un usuario y una meet con estado _cancelled_, se hace un POST a  /meets/:id/interest con el usuario creado como usuario loggeado.
- Probar interesarse en una meet completada: Se crea un usuario y una meet con una fecha expirada, NO se pone el estado _completed_ de primeras (esto con el propósito de probar la actualización en cada petición del estado de una meet). Luego se hace un POST a  /meets/:id/interest y efectivamente se actualiza primero el estado de la meet y luego retorna error al intentar agregar al usuario a la lista de interesados.

#### Checklist
- [x] Changelog (updated). *
- [x] Test unitarios. *
- [x] Test de integración. **

*  Obligatorio
** Si aplica