### PR TITLE
Updated logic for pending meets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
++ [[Backend-403]](https://www.notion.so/Talle-S-L-gica-de-reuni-n-pediente-c524355484fd4804ba10e00f4894bbe2)
++ Logic for pending meetings. Now when a user create a topic, the system creates a pending meeting for that topic.
+
 + [[Backend-376]](https://www.notion.so/Talle-M-Ver-Perfil-de-usuario-b065b109535e4611b54bdec3ecb4a136?pvs=4)
 + New /profile/teach, /profile/learn, /users/:id/teach and /users/:id/learn endpoints.
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -32,7 +32,8 @@ class TopicsController < ApplicationController
   def create
     begin
       topic = Topic.create!(topic_params)
-      AvailabilityTutor.create!(user_id: @current_user.first.id, topic_id: topic.id)
+      availability = AvailabilityTutor.create!(user_id: @current_user.first.id, topic_id: topic.id)
+      MeetsService.create_pending_meet({ availability_tutor_id: availability.id, link: topic.link, status: "pending" })
       render json: { message: I18n.t("success.topics.created") }, status: :created
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: e.message }, status: :unprocessable_entity

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,18 +1,18 @@
 class Topic < ApplicationRecord
-    belongs_to :subject
-    # before_create :validate_show_email
+  belongs_to :subject
+  # before_create :validate_show_email
 
-    has_one :availability_tutor, dependent: :destroy
-    has_one :tutor, through: :availability_tutor, source: :user
+  has_one :availability_tutor, dependent: :destroy
+  has_one :tutor, through: :availability_tutor, source: :user
 
-    has_many :student_topics, dependent: :destroy
-    has_many :student_users, through: :student_topics
+  has_many :student_topics, dependent: :destroy
+  has_many :student_users, through: :student_topics
 
-    validates :name, uniqueness: true
-    validates :name, :subject_id, presence: true
-    validates :show_email, inclusion: { in: [ true, false ] }
+  validates :name, uniqueness: true
+  validates :name, :subject_id, presence: true
+  validates :show_email, inclusion: { in: [ true, false ] }
 
-    scope :for_user, ->(id) { joins(:availability_tutor).where(availability_tutors: { user_id: id }) }
+  scope :for_user, ->(id) { joins(:availability_tutor).where(availability_tutors: { user_id: id }) }
 
   # private
   # def validate_show_email

--- a/app/services/meets_service.rb
+++ b/app/services/meets_service.rb
@@ -4,6 +4,14 @@ class MeetsService
       @user = user
     end
 
+    def self.create_pending_meet(meet_params)
+      if Meet.find_by(availability_tutor_id: meet_params[:availability_tutor_id], status: "pending")
+        raise ActiveRecord::RecordInvalid, I18n.t("error.meets.pending_meet")
+      else
+        Meet.create!(meet_params)
+      end
+    end
+
     # Class method to mark finished meets based on date
     def self.date_check
       Meet.mark_finished_meets

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,9 +46,9 @@ en:
       failed: "Failed to %{action} meet"
       already_status: "Meet already %{status}"
       already_interested: "User already interested in this meet"
-      tutor_interest: "Tutor can't be interested in his own meet"
       invalid_status: "Meet already cancelled"
       tutor_interested: "Tutor can't be interested in his own meet"
+      pending_meet: "Pending meet already exists"
     universities:
       not_found: "University not found"
     subjects:

--- a/spec/requests/meets_spec.rb
+++ b/spec/requests/meets_spec.rb
@@ -202,7 +202,7 @@ let!(:career) { FactoryBot.create(:career, university: university) }
       post "/meets/#{meet.id}/interesteds",
         headers: { "Authorization" => "Bearer #{token}" }
       expect(response).to have_http_status(:bad_request)
-      expect(JSON.parse(response.body)["error"]).to eq(I18n.t("error.meets.tutor_interest"))
+      expect(JSON.parse(response.body)["error"]).to eq(I18n.t("error.meets.tutor_interested"))
     end
 
     it "Meet already cancelled or completed" do

--- a/spec/requests/topic_spec.rb
+++ b/spec/requests/topic_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe "Topics", type: :request do
         expect(newTopic.link).to eq("New link")
         expect(newTopic.show_email).to eq(true)
         expect(newTopic.subject.id).to eq(subject.id)
+        meet = Meet.find_by(availability_tutor_id: newTopic.availability_tutor.id)
+        expect(meet.status).to eq("pending")
+        expect(meet.date_time).to be_nil
+        expect(meet.link).to eq(newTopic.link)
       end
     end
 


### PR DESCRIPTION
# PULL REQUEST

### Descripción
Se agrega la lógica para que siempre exista una meet pendiente asociada a un tema.

### Links requerimiento
[[Backend-403]](https://www.notion.so/Talle-S-L-gica-de-reuni-n-pediente-c524355484fd4804ba10e00f4894bbe2)

#### Test
Test unitraios modificados para chequear creación de meets.

#### Checklist
- [x] Changelog (updated). *
- [x] Test unitarios. *
- [x] Test de integración. **
