### PR TITLE
en teach y learn se busca por el user y no el current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.3]
 
+## [1.1.4]
+
+### Fixed
++ [[Backend-446]](https://www.notion.so/Bug-Report-Talle-S-Id-incorrecto-al-buscar-perfil-13a24a6692a4804da2c2e2a1681a01e2?pvs=4)
++ User controller: learn & teach searches by the user got by params
+
+
+## [1.1.3]
+ git commit -m "en teach y learn se busca por el user y no el current user"
 ### Fixed
 + [[Backend-440]](https://www.notion.so/Talle-S-Fix-endpoint-users-id-y-nuevo-endpoint-users-id-proposed_meets-b4d8d945eefe459e9471c6b90f0fcd81?pvs=4)
 + Endpoint /users/:id now works and new endpoint /users/:id/proposed_meets

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
     def teach
       user = User.where(id: params[:id])
       if user.present?
-          render json: teach_response(@current_user.first), status: :ok
+          render json: teach_response(user.first), status: :ok
       else
           render json: { error: I18n.t("error.users.not_found") }, status: 404
       end
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
     def learn
       user = User.where(id: params[:id])
       if user.present?
-          render json: learn_response(@current_user.first), status: :ok
+          render json: learn_response(user.first), status: :ok
       else
           render json: { error: I18n.t("error.users.not_found") }, status: 404
       end


### PR DESCRIPTION
# PULL REQUEST

### Descripción
+ User controller: learn & teach searches by the user got by params

### Links requerimiento
https://www.notion.so/Bug-Report-Talle-S-Id-incorrecto-al-buscar-perfil-13a24a6692a4804da2c2e2a1681a01e2?pvs=4

#### Test
![image](https://github.com/user-attachments/assets/3ab6bcba-6caf-4c4c-9fd4-aa9dbe857d19)

#### Checklist
- [x] Changelog (updated). *
- [ ] Swagger (updated). **
- [ ] Documentation (updated). **
- [ ] Actualizar Librerías
- [ ] Configuraciones (requiere actualizar o crear, listar valores). **
- [x] Test unitarios. *
- [ ] Test de integración. **

*  Obligatorio
** Si aplica